### PR TITLE
[Style] Add a space after the `lexical-binding` variable

### DIFF
--- a/php-runtime.el
+++ b/php-runtime.el
@@ -1,4 +1,4 @@
-;;; php-runtime.el --- Language binding bridge to PHP -*- lexical-binding:t -*-
+;;; php-runtime.el --- Language binding bridge to PHP -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017 USAMI Kenta
 


### PR DESCRIPTION
This patch changes the file-local variable definition from...

    -*- lexical-binding:t -*-

...to...

    -*- lexical-binding: t -*-

...instead.  There is absolutely *nothing* in the official GNU Emacs
Lisp Reference which says that this space is necessary.  In fact, its
absence does not prevent the variable from having the intended effect.
However, use of the space is ubiquitous.  I have personally never seen
any other code omit the space.  Using Emacs' built-in commands
`add-file-local-variable` and `add-file-local-variable-prop-line` also
always adds this space.

This patch changes no logic or behavior.  It does nothing except
literally add a single whitespace character to the source.  The
reasons for this change is, however, not only those described above.
The most import reason. and the impetus for this patch, is to improve
readability.  The less often that programmers see something "strange"
the less distracted they are, allowing them to focus on issues which
are genuinely important to a project.  When I began reading the code
for `php-runtime.el` the *very first* thing that I noticed was the
lack of whitespace in the file-local variable---leading to the time
and effort creating this patch.  Imagine if all of that time had be
used working on more important aspects on the project.

And I very seriously doubt that I am the only Emacs Lisp programmer
whe would notice the missing space.

Signed-off-by: Eric James Michael Ritz <ericjmritz@yandex.com>