### PR TITLE
[Fix] Find the correct PHP executable by default

### DIFF
--- a/php-runtime.el
+++ b/php-runtime.el
@@ -45,7 +45,7 @@
   :group 'processes
   :group 'php)
 
-(defcustom php-runtime-php-executable (and (executable-find "php") "php")
+(defcustom php-runtime-php-executable (or (executable-find "php") "php")
   "A command name or path to PHP executable."
   :group 'php-runtime
   :type 'string)


### PR DESCRIPTION
We use the customizable variable `php-runtime-php-executable` to
determine where the user installed PHP on his or her system.  However,
the default value for that variable is incorrect.  The default is:

    (and (executable-find "php") "php")

This is a common, sensible practice.  We attempt to use the standard
GNU Emacs function `executable-find` to get the location of the
program, but failing that we use a reasonable default.  However this
specific code has a boolean logic problem: what we want is the result
of `executable-find` **OR** our default value.  But since we use the
`(and ...)` conditional this will never happen; if `executable-find`
returns a path to the PHP executable we do not use it.  For example:

    (executable-find "php")
        => "/usr/local/bin/php"

    (and (executable-find "php") "php")
        => "php"

This patch replaces the `and` with `or` so that if `executable-find`
returns a meaningful value then we will actually use that.

Signed-off-by: Eric James Michael Ritz <ericjmritz@yandex.com>