### PR TITLE
Fix package names to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: emacs-lisp
 sudo: required
 
 before_install:
-  - sudo apt-get install php emacs-nox
+  - sudo apt-get install php5 emacs24-nox
 
 script:
   - emacs -Q --batch --eval '(message (emacs-version))'


### PR DESCRIPTION
These package names are not exists.
The following packages seem to exist indeed.

- https://packages.ubuntu.com/trusty/emacs24-nox
- https://packages.ubuntu.com/trusty/php5